### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 from setuptools import find_packages, setup
-from e2e_mlops_ado import __version__
 
 setup(
     name="e2e_mlops_ado",
     packages=find_packages(exclude=["tests", "tests.*"]),
     setup_requires=["wheel"],
-    version=__version__,
+    version=0.1,
     description="",
     author=""
 )


### PR DESCRIPTION
quick fix for error "ModuleNotFoundError: No module named 'e2e_mlops_ado'" while pip setup.py install